### PR TITLE
shift the old build files to docs_old

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 MKDOCS_IMAGE ?= intel-retail-mkdocs
 
 clean-docs:
-	rm -rf docs/
+	rm -rf docs_temp_old/
 
 docs: clean-docs
 	mkdocs build

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: "https://intel-retail.github.io/documentation/"
 repo_name: "intel-retail/documentation"
 repo_url: "https://github.com/intel-retail/documentation"
 docs_dir: ./docs_src
-site_dir: ./docs
+site_dir: ./docs_temp_old
 copyright: 'Copyright &copy; 2024 Intel Corporation'
 use_directory_urls: false
 theme:


### PR DESCRIPTION
## PR Checklist

The firs step to restructure docs around central publishing pipeline, for docs.openedgeplatform.intel.com

the old mkDocs build will remain functional, just moving the temp folder. Next step is to create the docs folder with the intended file structure (for the Sphinx page builder).

- [] Added label to the Pull Request for easier discoverability and search
- [x] Commit Message meets guidelines as indicated in the URL https://github.com/intel-retail/automated-self-checkout/blob/main/CONTRIBUTING.md
- [ ] PR introduces changes that breaks compatibility with other modules (If YES, please provide details below)
- [x] No Employer Confidential details are added


